### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [v1.0.1](https://github.com/azurenoops/terraform-azurerm-overlays-app-service/tree/v1.0.1) (2023-05-03)
+## [v1.0.1](https://github.com/POps-Rox/tf-az-overlays-appservice/tree/v1.0.1) (2023-05-03)
 
-## [v1.0.0](https://github.com/azurenoops/terraform-azurerm-overlays-app-service/tree/v1.0.0) (2023-05-03)
+## [v1.0.0](https://github.com/POps-Rox/tf-az-overlays-appservice/tree/v1.0.0) (2023-05-03)
 
 
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure App Service Web (Linux or Windows) Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-app-service/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-app-service/azurerm/)
 
-This Overlay terraform module can create a an Azure Service Plan with a an Azure App Service Web/Function (Linux or Windows) associated with an Application Insights component and manage related parameters (Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay terraform module can create a an Azure Service Plan with a an Azure App Service Web/Function (Linux or Windows) associated with an Application Insights component and manage related parameters (Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure App Service Web (Linux or Windows) Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-app-service/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-app-service/azurerm/)
 
-This Overlay terraform module can create a an Azure Service Plan with a an Azure App Service Web/Function (Linux or Windows) associated with an Application Insights component and manage related parameters (Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay terraform module can create a an Azure Service Plan with a an Azure App Service Web/Function (Linux or Windows) associated with an Application Insights component and manage related parameters (Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 

--- a/examples/linux_app_service/versions.tf
+++ b/examples/linux_app_service/versions.tf
@@ -5,8 +5,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/linux_app_service/versions.tf
+++ b/examples/linux_app_service/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/linux_app_service/versions.tf
+++ b/examples/linux_app_service/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/linux_app_service_with_acr/versions.tf
+++ b/examples/linux_app_service_with_acr/versions.tf
@@ -5,8 +5,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/linux_app_service_with_acr/versions.tf
+++ b/examples/linux_app_service_with_acr/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/linux_app_service_with_acr/versions.tf
+++ b/examples/linux_app_service_with_acr/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/linux_function_app/versions.tf
+++ b/examples/linux_function_app/versions.tf
@@ -5,8 +5,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/linux_function_app/versions.tf
+++ b/examples/linux_function_app/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/linux_function_app/versions.tf
+++ b/examples/linux_function_app/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/windows_app_service/versions.tf
+++ b/examples/windows_app_service/versions.tf
@@ -5,8 +5,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/windows_app_service/versions.tf
+++ b/examples/windows_app_service/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/windows_app_service/versions.tf
+++ b/examples/windows_app_service/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/windows_function_app/versions.tf
+++ b/examples/windows_function_app/versions.tf
@@ -5,8 +5,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/windows_function_app/versions.tf
+++ b/examples/windows_function_app/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/windows_function_app/versions.tf
+++ b/examples/windows_function_app/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,8 +8,8 @@ locals {
 
   resource_group_name             = element(coalescelist(data.azurerm_resource_group.rg.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location                        = element(coalescelist(data.azurerm_resource_group.rg.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  app_service_name                = coalesce(var.app_service_custom_name, data.popsrox_utils_resource_name.app_service_web.result)
-  app_service_plan_name           = coalesce(var.app_service_plan_custom_name, data.popsrox_utils_resource_name.app_service_plan.result)
-  app_user_assigned_identity_name = data.popsrox_utils_resource_name.app_user_assigned_identity.result
-  app_service_app_insights_name   = data.popsrox_utils_resource_name.application_insights.result
+  app_service_name                = coalesce(var.app_service_custom_name, data.popsrox_resource_name.app_service_web.result)
+  app_service_plan_name           = coalesce(var.app_service_plan_custom_name, data.popsrox_resource_name.app_service_plan.result)
+  app_user_assigned_identity_name = data.popsrox_resource_name.app_user_assigned_identity.result
+  app_service_app_insights_name   = data.popsrox_resource_name.application_insights.result
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,8 +8,8 @@ locals {
 
   resource_group_name             = element(coalescelist(data.azurerm_resource_group.rg.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location                        = element(coalescelist(data.azurerm_resource_group.rg.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  app_service_name                = coalesce(var.app_service_custom_name, data.azurenoopsutils_resource_name.app_service_web.result)
-  app_service_plan_name           = coalesce(var.app_service_plan_custom_name, data.azurenoopsutils_resource_name.app_service_plan.result)
-  app_user_assigned_identity_name = data.azurenoopsutils_resource_name.app_user_assigned_identity.result
-  app_service_app_insights_name   = data.azurenoopsutils_resource_name.application_insights.result
+  app_service_name                = coalesce(var.app_service_custom_name, data.popsrox_utils_resource_name.app_service_web.result)
+  app_service_plan_name           = coalesce(var.app_service_plan_custom_name, data.popsrox_utils_resource_name.app_service_plan.result)
+  app_user_assigned_identity_name = data.popsrox_utils_resource_name.app_user_assigned_identity.result
+  app_service_app_insights_name   = data.popsrox_utils_resource_name.application_insights.result
 }

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "azurenoopsutils_resource_name" "app_service_web" {
+data "popsrox_utils_resource_name" "app_service_web" {
   name          = var.workload_name
   resource_type = "azurerm_app_service"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]
@@ -14,7 +14,7 @@ data "azurenoopsutils_resource_name" "app_service_web" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "app_service_plan" {
+data "popsrox_utils_resource_name" "app_service_plan" {
   name          = var.workload_name
   resource_type = "azurerm_app_service_plan"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]
@@ -24,7 +24,7 @@ data "azurenoopsutils_resource_name" "app_service_plan" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "application_insights" {
+data "popsrox_utils_resource_name" "application_insights" {
   name          = var.workload_name
   resource_type = "azurerm_application_insights"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]
@@ -34,7 +34,7 @@ data "azurenoopsutils_resource_name" "application_insights" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "app_user_assigned_identity" {
+data "popsrox_utils_resource_name" "app_user_assigned_identity" {
   name          = var.workload_name
   resource_type = "azurerm_user_assigned_identity"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "popsrox_utils_resource_name" "app_service_web" {
+data "popsrox_resource_name" "app_service_web" {
   name          = var.workload_name
   resource_type = "azurerm_app_service"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]
@@ -14,7 +14,7 @@ data "popsrox_utils_resource_name" "app_service_web" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "app_service_plan" {
+data "popsrox_resource_name" "app_service_plan" {
   name          = var.workload_name
   resource_type = "azurerm_app_service_plan"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]
@@ -24,7 +24,7 @@ data "popsrox_utils_resource_name" "app_service_plan" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "application_insights" {
+data "popsrox_resource_name" "application_insights" {
   name          = var.workload_name
   resource_type = "azurerm_application_insights"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]
@@ -34,7 +34,7 @@ data "popsrox_utils_resource_name" "application_insights" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "app_user_assigned_identity" {
+data "popsrox_resource_name" "app_user_assigned_identity" {
   name          = var.workload_name
   resource_type = "azurerm_user_assigned_identity"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]

--- a/versions.tf
+++ b/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace all `azurenoops/azurenoopsutils` provider references with `POps-Rox/popsrox-utils` across root module, 5 example sub-configs, naming data sources, locals, and documentation.

## Changes
- `versions.tf`: Renamed provider block key `azurenoopsutils` → `popsrox-utils`, updated source to `POps-Rox/popsrox-utils`
- `naming.tf`: Updated all 4 data source types `azurenoopsutils_resource_name` → `popsrox_utils_resource_name`
- `locals.naming.tf`: Updated all 4 data references to match new type
- `CHANGELOG.md`: Updated org (`azurenoops` → `POps-Rox`) and repo name (`terraform-azurerm-overlays-app-service` → `tf-az-overlays-appservice`) in URLs
- `README.md`: Updated registry badge and module source URLs
- `docs/index.md`: Same updates as README.md
- `examples/linux_app_service/versions.tf`: Provider renamed and source updated
- `examples/windows_app_service/versions.tf`: Provider renamed and source updated
- `examples/linux_function_app/versions.tf`: Provider renamed and source updated
- `examples/linux_app_service_with_acr/versions.tf`: Provider renamed and source updated
- `examples/windows_function_app/versions.tf`: Provider renamed and source updated

## Testing
- Confirmed zero remaining `azurenoops` references in `.tf` and `.md` files via grep
- `terraform fmt -recursive` passes with no changes

Closes #7