### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-appservice
+  name: terraform-az-overlays-appservice
   description: Terraform overlay module for Azure App Service
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-appservice
+    github.com/project-slug: POps-Rox/terraform-az-overlays-appservice
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-appservice
+    - url: https://github.com/POps-Rox/terraform-az-overlays-appservice
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/linux_app_service/dependencies.tf
+++ b/examples/linux_app_service/dependencies.tf
@@ -6,7 +6,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/linux_app_service/main.tf
+++ b/examples/linux_app_service/main.tf
@@ -7,7 +7,7 @@ module "mod_app_service" {
   providers = {
     azurerm = azurerm
   }
-  #source  = "github.com/POps-Rox/tf-az-overlays-appservice"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice"
   #version = "x.x.x"
 
   depends_on = [azurerm_resource_group.app-rg]

--- a/examples/linux_app_service_with_acr/dependencies.tf
+++ b/examples/linux_app_service_with_acr/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/linux_app_service_with_acr/main.tf
+++ b/examples/linux_app_service_with_acr/main.tf
@@ -7,7 +7,7 @@ module "mod_app_service" {
   providers = {
     azurerm = azurerm
   }
-  #source  = "github.com/POps-Rox/tf-az-overlays-appservice"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice"
   #version = "x.x.x"
 
   depends_on = [azurerm_resource_group.app-rg]

--- a/examples/linux_function_app/dependencies.tf
+++ b/examples/linux_function_app/dependencies.tf
@@ -6,7 +6,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/linux_function_app/main.tf
+++ b/examples/linux_function_app/main.tf
@@ -7,7 +7,7 @@ module "mod_app_service" {
   providers = {
     azurerm = azurerm
   }
-  #source  = "github.com/POps-Rox/tf-az-overlays-appservice"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice"
   #version = "x.x.x"
 
   depends_on = [azurerm_resource_group.app-rg]

--- a/examples/windows_app_service/dependencies.tf
+++ b/examples/windows_app_service/dependencies.tf
@@ -6,7 +6,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/windows_app_service/main.tf
+++ b/examples/windows_app_service/main.tf
@@ -7,7 +7,7 @@ module "mod_app_service" {
   providers = {
     azurerm = azurerm
   }
-  #source  = "github.com/POps-Rox/tf-az-overlays-appservice"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice"
   #version = "x.x.x"
 
   depends_on = [azurerm_resource_group.app-rg]

--- a/examples/windows_function_app/dependencies.tf
+++ b/examples/windows_function_app/dependencies.tf
@@ -6,7 +6,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/windows_function_app/main.tf
+++ b/examples/windows_function_app/main.tf
@@ -7,7 +7,7 @@ module "mod_app_service" {
   providers = {
     azurerm = azurerm
   }
-  #source  = "github.com/POps-Rox/tf-az-overlays-appservice"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice"
   #version = "x.x.x"
 
   depends_on = [azurerm_resource_group.app-rg]

--- a/modules.appservice.acr.tf
+++ b/modules.appservice.acr.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_container_registry" {
-  source                       = "github.com/POps-Rox/tf-az-overlays-containerregistry"
+  source                       = "github.com/POps-Rox/terraform-az-overlays-containerregistry"
   count                        = var.create_app_container_registry ? 1 : 0
   existing_resource_group_name = local.resource_group_name
   location                     = local.location

--- a/modules.appservice.keyvault.tf
+++ b/modules.appservice.keyvault.tf
@@ -5,7 +5,7 @@ module "mod_key_vault" {
   depends_on = [
     azurerm_user_assigned_identity.app_identity
   ]
-  source = "github.com/POps-Rox/tf-az-overlays-keyvault"
+  source = "github.com/POps-Rox/terraform-az-overlays-keyvault"
   count  = var.create_app_keyvault ? 1 : 0
   providers = {
     azurerm     = azurerm

--- a/modules.appservice.storage.tf
+++ b/modules.appservice.storage.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_storage_account" {
-  source                       = "github.com/POps-Rox/tf-az-overlays-storageaccount"
+  source                       = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
   count                        = var.app_service_resource_type == "FunctionApp" ? 1 : 0
   location                     = local.location
   existing_resource_group_name = local.resource_group_name

--- a/resources.appservice.scaffolding.tf
+++ b/resources.appservice.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rg" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_app_resource_group ? 1 : 0
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.