### PR TITLE
fix: resolve 4.x validation/CI failures

### DIFF
--- a/resources.appservice.linux.tf
+++ b/resources.appservice.linux.tf
@@ -19,8 +19,10 @@ resource "azurerm_linux_web_app" "linuxapp" {
     api_management_api_id = var.linux_app_site_config.api_management_api_id
     app_command_line      = var.linux_app_site_config.app_command_line
     application_stack {
-      docker_image        = var.linux_app_site_config.application_stack.docker_image == null ? null : "${module.mod_container_registry.0.login_server}/${var.linux_app_site_config.application_stack.docker_image}"
-      docker_image_tag    = var.linux_app_site_config.application_stack.docker_image_tag == null ? null : var.linux_app_site_config.application_stack.docker_image_tag
+      # azurerm 4.x consolidated docker fields: `docker_image` + `docker_image_tag`
+      # are now `docker_image_name` ("image:tag") plus `docker_registry_url`.
+      docker_image_name   = var.linux_app_site_config.application_stack.docker_image == null ? null : "${var.linux_app_site_config.application_stack.docker_image}:${var.linux_app_site_config.application_stack.docker_image_tag == null ? "latest" : var.linux_app_site_config.application_stack.docker_image_tag}"
+      docker_registry_url = var.linux_app_site_config.application_stack.docker_image == null ? null : "https://${module.mod_container_registry.0.login_server}"
       dotnet_version      = var.linux_app_site_config.application_stack.dotnet_version == null ? null : var.linux_app_site_config.application_stack.dotnet_version
       go_version          = var.linux_app_site_config.application_stack.go_version
       java_server         = var.linux_app_site_config.application_stack.java_server

--- a/resources.appservice.windows.tf
+++ b/resources.appservice.windows.tf
@@ -20,10 +20,11 @@ resource "azurerm_windows_web_app" "appService" {
     api_management_api_id = var.windows_app_site_config.api_management_api_id
     app_command_line      = var.windows_app_site_config.app_command_line
     application_stack {
-      current_stack                = var.windows_app_site_config.application_stack.current_stack
-      docker_container_name        = var.windows_app_site_config.application_stack.docker_container_name
-      docker_container_registry    = var.create_app_container_registry ? module.mod_container_registry.0.login_server : var.windows_app_site_config.application_stack.docker_container_registry
-      docker_container_tag         = var.windows_app_site_config.application_stack.docker_container_tag
+      current_stack = var.windows_app_site_config.application_stack.current_stack
+      # azurerm 4.x consolidated docker fields: `docker_container_*` are now
+      # `docker_image_name` ("image:tag") plus `docker_registry_url`.
+      docker_image_name            = var.windows_app_site_config.application_stack.docker_container_name == null ? null : "${var.windows_app_site_config.application_stack.docker_container_name}:${var.windows_app_site_config.application_stack.docker_container_tag == null ? "latest" : var.windows_app_site_config.application_stack.docker_container_tag}"
+      docker_registry_url          = var.windows_app_site_config.application_stack.docker_container_name == null ? null : "https://${var.create_app_container_registry ? module.mod_container_registry.0.login_server : var.windows_app_site_config.application_stack.docker_container_registry}"
       dotnet_version               = var.windows_app_site_config.application_stack.dotnet_version
       dotnet_core_version          = var.windows_app_site_config.application_stack.dotnet_core_version
       tomcat_version               = var.windows_app_site_config.application_stack.tomcat_version


### PR DESCRIPTION
Post-merge fix for CI failures introduced by Phase 1 4.x migration.

**Failing job:** Terraform Validate
**Root cause:** azurerm 4.x consolidated the docker arguments on `azurerm_linux_web_app.application_stack` and `azurerm_windows_web_app.application_stack`:
- Linux: `docker_image` + `docker_image_tag` → `docker_image_name` ("image:tag") + `docker_registry_url`
- Windows: `docker_container_name` + `docker_container_tag` + `docker_container_registry` → `docker_image_name` + `docker_registry_url`

**Fix:** Map the existing public variables (`docker_image`, `docker_image_tag`, `docker_container_name`, `docker_container_tag`, `docker_container_registry`) into the new 4.x argument shape internally. The module's input contract is unchanged.

> Pairs with POps-Rox/terraform-az-overlays-keyvault#25 (removing the legacy `providers.tf` from the keyvault module so this module can call it with `count` + explicit `providers = {…}`).

Validated locally:
- `terraform fmt -recursive -check` ✅
- `terraform validate` (root) ✅
- `terraform validate` (all 5 examples: linux_app_service, linux_app_service_with_acr, linux_function_app, windows_app_service, windows_function_app) ✅