### PR TITLE
chore: auto-fix mechanical tflint violations

### DIFF
--- a/examples/linux_app_service/dependencies.tf
+++ b/examples/linux_app_service/dependencies.tf
@@ -6,7 +6,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = "eastus"
 }

--- a/examples/linux_app_service/main.tf
+++ b/examples/linux_app_service/main.tf
@@ -7,7 +7,7 @@ module "mod_app_service" {
   providers = {
     azurerm = azurerm
   }
-  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice?ref=v2.0.0"
   #version = "x.x.x"
 
   depends_on = [azurerm_resource_group.app-rg]

--- a/examples/linux_app_service_with_acr/dependencies.tf
+++ b/examples/linux_app_service_with_acr/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = "eastus"
 }

--- a/examples/linux_app_service_with_acr/main.tf
+++ b/examples/linux_app_service_with_acr/main.tf
@@ -7,7 +7,7 @@ module "mod_app_service" {
   providers = {
     azurerm = azurerm
   }
-  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice?ref=v2.0.0"
   #version = "x.x.x"
 
   depends_on = [azurerm_resource_group.app-rg]

--- a/examples/linux_function_app/dependencies.tf
+++ b/examples/linux_function_app/dependencies.tf
@@ -6,7 +6,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = "eastus"
 }

--- a/examples/linux_function_app/main.tf
+++ b/examples/linux_function_app/main.tf
@@ -7,7 +7,7 @@ module "mod_app_service" {
   providers = {
     azurerm = azurerm
   }
-  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice?ref=v2.0.0"
   #version = "x.x.x"
 
   depends_on = [azurerm_resource_group.app-rg]

--- a/examples/windows_app_service/dependencies.tf
+++ b/examples/windows_app_service/dependencies.tf
@@ -6,7 +6,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = "eastus"
 }

--- a/examples/windows_app_service/main.tf
+++ b/examples/windows_app_service/main.tf
@@ -7,7 +7,7 @@ module "mod_app_service" {
   providers = {
     azurerm = azurerm
   }
-  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice?ref=v2.0.0"
   #version = "x.x.x"
 
   depends_on = [azurerm_resource_group.app-rg]

--- a/examples/windows_function_app/dependencies.tf
+++ b/examples/windows_function_app/dependencies.tf
@@ -6,7 +6,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = "eastus"
 }

--- a/examples/windows_function_app/main.tf
+++ b/examples/windows_function_app/main.tf
@@ -7,7 +7,7 @@ module "mod_app_service" {
   providers = {
     azurerm = azurerm
   }
-  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-appservice?ref=v2.0.0"
   #version = "x.x.x"
 
   depends_on = [azurerm_resource_group.app-rg]

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -6,8 +6,8 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  resource_group_name             = element(coalescelist(data.azurerm_resource_group.rg.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
-  location                        = element(coalescelist(data.azurerm_resource_group.rg.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
+  resource_group_name             = element(coalescelist(data.azurerm_resource_group.rg[*].name, module.mod_scaffold_rg[*].resource_group_name, [""]), 0)
+  location                        = element(coalescelist(data.azurerm_resource_group.rg[*].location, module.mod_scaffold_rg[*].resource_group_location, [""]), 0)
   app_service_name                = coalesce(var.app_service_custom_name, data.popsrox_resource_name.app_service_web.result)
   app_service_plan_name           = coalesce(var.app_service_plan_custom_name, data.popsrox_resource_name.app_service_plan.result)
   app_user_assigned_identity_name = data.popsrox_resource_name.app_user_assigned_identity.result

--- a/modules.appservice.acr.tf
+++ b/modules.appservice.acr.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_container_registry" {
-  source                       = "github.com/POps-Rox/terraform-az-overlays-containerregistry"
+  source                       = "github.com/POps-Rox/terraform-az-overlays-containerregistry?ref=v2.0.0"
   count                        = var.create_app_container_registry ? 1 : 0
   existing_resource_group_name = local.resource_group_name
   location                     = local.location

--- a/modules.appservice.keyvault.tf
+++ b/modules.appservice.keyvault.tf
@@ -5,7 +5,7 @@ module "mod_key_vault" {
   depends_on = [
     azurerm_user_assigned_identity.app_identity
   ]
-  source = "github.com/POps-Rox/terraform-az-overlays-keyvault"
+  source = "github.com/POps-Rox/terraform-az-overlays-keyvault?ref=v2.0.0"
   count  = var.create_app_keyvault ? 1 : 0
   providers = {
     azurerm     = azurerm

--- a/modules.appservice.storage.tf
+++ b/modules.appservice.storage.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_storage_account" {
-  source                       = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
+  source                       = "github.com/POps-Rox/terraform-az-overlays-storageaccount?ref=v2.0.0"
   count                        = var.app_service_resource_type == "FunctionApp" ? 1 : 0
   location                     = local.location
   existing_resource_group_name = local.resource_group_name

--- a/outputs-app-insights.tf
+++ b/outputs-app-insights.tf
@@ -7,26 +7,26 @@
 
 output "application_insights_id" {
   description = "Id of the Application Insights associated to the App Service"
-  value       = try(azurerm_application_insights.app_service_app_insights.0.id, null)
+  value       = try(azurerm_application_insights.app_service_app_insights[0].id, null)
 }
 
 output "application_insights_name" {
   description = "Name of the Application Insights associated to the App Service"
-  value       = try(azurerm_application_insights.app_service_app_insights.0.name, null)
+  value       = try(azurerm_application_insights.app_service_app_insights[0].name, null)
 }
 
 output "application_insights_app_id" {
   description = "App id of the Application Insights associated to the App Service"
-  value       = try(azurerm_application_insights.app_service_app_insights.0.app_id, null)
+  value       = try(azurerm_application_insights.app_service_app_insights[0].app_id, null)
 }
 
 output "application_insights_instrumentation_key" {
   description = "Instrumentation key of the Application Insights associated to the App Service"
-  value       = try(azurerm_application_insights.app_service_app_insights.0.instrumentation_key, null)
+  value       = try(azurerm_application_insights.app_service_app_insights[0].instrumentation_key, null)
   sensitive   = true
 }
 
 output "application_insights_application_type" {
   description = "Application Type of the Application Insights associated to the App Service"
-  value       = try(azurerm_application_insights.app_service_app_insights.0.application_type, null)
+  value       = try(azurerm_application_insights.app_service_app_insights[0].application_type, null)
 }

--- a/outputs-linux-function-app.tf
+++ b/outputs-linux-function-app.tf
@@ -7,37 +7,37 @@
 
 output "linux_function_app_service_id" {
   description = "Id of the Linux App Service"
-  value       = try(azurerm_linux_function_app.func.0.id, null)
+  value       = try(azurerm_linux_function_app.func[0].id, null)
 }
 
 output "linux_function_app_service_name" {
   description = "Name of the Linux App Service"
-  value       = try(azurerm_linux_function_app.func.0.name, null)
+  value       = try(azurerm_linux_function_app.func[0].name, null)
 }
 
 output "linux_function_app_service_default_site_hostname" {
   description = "The Default Hostname associated with the Linux App Service"
-  value       = try(azurerm_linux_function_app.func.0.default_hostname, null)
+  value       = try(azurerm_linux_function_app.func[0].default_hostname, null)
 }
 
 output "linux_function_app_service_outbound_ip_addresses" {
   description = "Outbound IP addresses of the App Service"
-  value       = try(split(",", azurerm_linux_function_app.func.0.outbound_ip_addresses), null)
+  value       = try(split(",", azurerm_linux_function_app.func[0].outbound_ip_addresses), null)
 }
 
 output "linux_function_app_service_possible_outbound_ip_addresses" {
   description = "Possible outbound IP addresses of the App Service"
-  value       = try(split(",", azurerm_linux_function_app.func.0.possible_outbound_ip_addresses), null)
+  value       = try(split(",", azurerm_linux_function_app.func[0].possible_outbound_ip_addresses), null)
 }
 
 output "linux_function_app_service_site_credential" {
   description = "Site credential block of the App Service"
-  value       = try(azurerm_linux_function_app.func.0.site_credential, null)
+  value       = try(azurerm_linux_function_app.func[0].site_credential, null)
 }
 
 output "linux_function_app_service_identity_service_principal_id" {
   description = "Id of the Service principal identity of the App Service"
-  value       = try(azurerm_linux_function_app.func.0.identity[0].principal_id, null)
+  value       = try(azurerm_linux_function_app.func[0].identity[0].principal_id, null)
 }
 
 output "linux_function_app_service_slot_name" {

--- a/outputs-linux-web-app.tf
+++ b/outputs-linux-web-app.tf
@@ -7,37 +7,37 @@
 
 output "linux_app_service_id" {
   description = "Id of the Linux App Service"
-  value       = try(azurerm_linux_web_app.linuxapp.0.id, null)
+  value       = try(azurerm_linux_web_app.linuxapp[0].id, null)
 }
 
 output "linux_app_service_name" {
   description = "Name of the Linux App Service"
-  value       = try(azurerm_linux_web_app.linuxapp.0.name, null)
+  value       = try(azurerm_linux_web_app.linuxapp[0].name, null)
 }
 
 output "linux_app_service_default_site_hostname" {
   description = "The Default Hostname associated with the Linux App Service"
-  value       = try(azurerm_linux_web_app.linuxapp.0.default_hostname, null)
+  value       = try(azurerm_linux_web_app.linuxapp[0].default_hostname, null)
 }
 
 output "linux_app_service_outbound_ip_addresses" {
   description = "Outbound IP addresses of the App Service"
-  value       = try(split(",", azurerm_linux_web_app.linuxapp.0.outbound_ip_addresses), null)
+  value       = try(split(",", azurerm_linux_web_app.linuxapp[0].outbound_ip_addresses), null)
 }
 
 output "linux_app_service_possible_outbound_ip_addresses" {
   description = "Possible outbound IP addresses of the App Service"
-  value       = try(split(",", azurerm_linux_web_app.linuxapp.0.possible_outbound_ip_addresses), null)
+  value       = try(split(",", azurerm_linux_web_app.linuxapp[0].possible_outbound_ip_addresses), null)
 }
 
 output "linux_app_service_site_credential" {
   description = "Site credential block of the App Service"
-  value       = try(azurerm_linux_web_app.linuxapp.0.site_credential, null)
+  value       = try(azurerm_linux_web_app.linuxapp[0].site_credential, null)
 }
 
 output "linux_app_service_identity_service_principal_id" {
   description = "Id of the Service principal identity of the App Service"
-  value       = try(azurerm_linux_web_app.linuxapp.0.identity[0].principal_id, null)
+  value       = try(azurerm_linux_web_app.linuxapp[0].identity[0].principal_id, null)
 }
 
 output "linux_app_service_slot_name" {

--- a/outputs-service-plan.tf
+++ b/outputs-service-plan.tf
@@ -7,5 +7,5 @@
 
 output "service_plan_id" {
   description = "ID of the Service Plan"
-  value       = azurerm_service_plan.asp.0.id
+  value       = azurerm_service_plan.asp[0].id
 }

--- a/outputs-windows-function-app.tf
+++ b/outputs-windows-function-app.tf
@@ -7,37 +7,37 @@
 
 output "windows_function_app_service_id" {
   description = "Id of the Linux App Service"
-  value       = try(azurerm_windows_function_app.func.0.id, null)
+  value       = try(azurerm_windows_function_app.func[0].id, null)
 }
 
 output "windows_function_app_service_name" {
   description = "Name of the Linux App Service"
-  value       = try(azurerm_windows_function_app.func.0.name, null)
+  value       = try(azurerm_windows_function_app.func[0].name, null)
 }
 
 output "windows_function_app_service_default_site_hostname" {
   description = "The Default Hostname associated with the Linux App Service"
-  value       = try(azurerm_windows_function_app.func.0.default_hostname, null)
+  value       = try(azurerm_windows_function_app.func[0].default_hostname, null)
 }
 
 output "windows_function_app_service_outbound_ip_addresses" {
   description = "Outbound IP addresses of the App Service"
-  value       = try(split(",", azurerm_windows_function_app.func.0.outbound_ip_addresses), null)
+  value       = try(split(",", azurerm_windows_function_app.func[0].outbound_ip_addresses), null)
 }
 
 output "windows_function_app_service_possible_outbound_ip_addresses" {
   description = "Possible outbound IP addresses of the App Service"
-  value       = try(split(",", azurerm_windows_function_app.func.0.possible_outbound_ip_addresses), null)
+  value       = try(split(",", azurerm_windows_function_app.func[0].possible_outbound_ip_addresses), null)
 }
 
 output "windows_function_app_service_site_credential" {
   description = "Site credential block of the App Service"
-  value       = try(azurerm_windows_function_app.func.0.site_credential, null)
+  value       = try(azurerm_windows_function_app.func[0].site_credential, null)
 }
 
 output "windows_function_app_service_identity_service_principal_id" {
   description = "Id of the Service principal identity of the App Service"
-  value       = try(azurerm_windows_function_app.func.0.identity[0].principal_id, null)
+  value       = try(azurerm_windows_function_app.func[0].identity[0].principal_id, null)
 }
 
 output "windows_function_app_service_slot_name" {

--- a/outputs-windows-web-app.tf
+++ b/outputs-windows-web-app.tf
@@ -7,32 +7,32 @@
 
 output "windows_app_service_id" {
   description = "Id of the Windows App Service"
-  value       = try(azurerm_windows_web_app.appService.0.id, null)
+  value       = try(azurerm_windows_web_app.appService[0].id, null)
 }
 
 output "windows_app_service_name" {
   description = "Name of the Windows App Service"
-  value       = try(azurerm_windows_web_app.appService.0.name, null)
+  value       = try(azurerm_windows_web_app.appService[0].name, null)
 }
 
 output "windows_app_service_default_site_hostname" {
   description = "The Default Hostname associated with the Windows App Service"
-  value       = try(azurerm_windows_web_app.appService.0.default_hostname, null)
+  value       = try(azurerm_windows_web_app.appService[0].default_hostname, null)
 }
 
 output "windows_app_service_outbound_ip_addresses" {
   description = "Outbound IP addresses of the Windows App Service"
-  value       = try(split(",", azurerm_windows_web_app.appService.0.outbound_ip_addresses), null)
+  value       = try(split(",", azurerm_windows_web_app.appService[0].outbound_ip_addresses), null)
 }
 
 output "windows_app_service_possible_outbound_ip_addresses" {
   description = "Possible outbound IP addresses of the Windows App Service"
-  value       = try(split(",", azurerm_windows_web_app.appService.0.possible_outbound_ip_addresses), null)
+  value       = try(split(",", azurerm_windows_web_app.appService[0].possible_outbound_ip_addresses), null)
 }
 
 output "windows_app_service_site_credential" {
   description = "Site credential block of the Windows App Service"
-  value       = try(azurerm_windows_web_app.appService.0.site_credential, null)
+  value       = try(azurerm_windows_web_app.appService[0].site_credential, null)
 }
 
 output "windows_app_service_identity_service_principal_id" {

--- a/resources.appservice.function.linux.tf
+++ b/resources.appservice.function.linux.tf
@@ -12,9 +12,9 @@ resource "azurerm_linux_function_app" "func" {
   resource_group_name = local.resource_group_name
   location            = local.location
 
-  storage_account_name       = module.mod_storage_account.0.storage_account_name
-  storage_account_access_key = module.mod_storage_account.0.primary_access_key
-  service_plan_id            = azurerm_service_plan.asp.0.id
+  storage_account_name       = module.mod_storage_account[0].storage_account_name
+  storage_account_access_key = module.mod_storage_account[0].primary_access_key
+  service_plan_id            = azurerm_service_plan.asp[0].id
 
   key_vault_reference_identity_id = azurerm_user_assigned_identity.app_identity.id
 
@@ -106,7 +106,7 @@ resource "azurerm_linux_function_app_slot" "slot" {
   count                = var.app_service_plan_os_type == "Linux" && var.app_service_resource_type == "FunctionApp" ? var.deployment_slot_count : 0
   name                 = "${local.app_service_name}-slot-${count.index + 1}"
   function_app_id      = azurerm_linux_function_app.func[0].id
-  storage_account_name = module.mod_storage_account.0.storage_account_name
+  storage_account_name = module.mod_storage_account[0].storage_account_name
 
   site_config {}
 }

--- a/resources.appservice.function.windows.tf
+++ b/resources.appservice.function.windows.tf
@@ -12,9 +12,9 @@ resource "azurerm_windows_function_app" "func" {
   resource_group_name = local.resource_group_name
   location            = local.location
 
-  storage_account_name       = module.mod_storage_account.0.storage_account_name
-  storage_account_access_key = module.mod_storage_account.0.primary_access_key
-  service_plan_id            = azurerm_service_plan.asp.0.id
+  storage_account_name       = module.mod_storage_account[0].storage_account_name
+  storage_account_access_key = module.mod_storage_account[0].primary_access_key
+  service_plan_id            = azurerm_service_plan.asp[0].id
 
   key_vault_reference_identity_id = azurerm_user_assigned_identity.app_identity.id
   site_config {
@@ -83,7 +83,7 @@ resource "azurerm_windows_function_app_slot" "slot" {
   count                = var.app_service_plan_os_type == "Windows" && var.app_service_resource_type == "FunctionApp" ? var.deployment_slot_count : 0
   name                 = "${local.app_service_name}-slot-${count.index + 1}"
   function_app_id      = azurerm_windows_function_app.func[0].id
-  storage_account_name = module.mod_storage_account.0.storage_account_name
+  storage_account_name = module.mod_storage_account[0].storage_account_name
 
   site_config {}
 }

--- a/resources.appservice.keyvault.tf
+++ b/resources.appservice.keyvault.tf
@@ -6,7 +6,7 @@ resource "azurerm_key_vault_access_policy" "app_access_policy" {
     module.mod_key_vault,
     azurerm_user_assigned_identity.app_identity
   ]
-  key_vault_id = module.mod_key_vault.0.key_vault_id
+  key_vault_id = module.mod_key_vault[0].key_vault_id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_user_assigned_identity.app_identity.principal_id
 

--- a/resources.appservice.linux.tf
+++ b/resources.appservice.linux.tf
@@ -11,7 +11,7 @@ resource "azurerm_linux_web_app" "linuxapp" {
   name                = local.app_service_name
   resource_group_name = local.resource_group_name
   location            = local.location
-  service_plan_id     = var.create_app_service_plan == false && var.existing_app_service_plan_name != null ? data.azurerm_service_plan.existing_asp.0.id : azurerm_service_plan.asp.0.id
+  service_plan_id     = var.create_app_service_plan == false && var.existing_app_service_plan_name != null ? data.azurerm_service_plan.existing_asp[0].id : azurerm_service_plan.asp[0].id
 
   site_config {
     always_on             = var.linux_app_site_config.always_on
@@ -22,7 +22,7 @@ resource "azurerm_linux_web_app" "linuxapp" {
       # azurerm 4.x consolidated docker fields: `docker_image` + `docker_image_tag`
       # are now `docker_image_name` ("image:tag") plus `docker_registry_url`.
       docker_image_name   = var.linux_app_site_config.application_stack.docker_image == null ? null : "${var.linux_app_site_config.application_stack.docker_image}:${var.linux_app_site_config.application_stack.docker_image_tag == null ? "latest" : var.linux_app_site_config.application_stack.docker_image_tag}"
-      docker_registry_url = var.linux_app_site_config.application_stack.docker_image == null ? null : "https://${module.mod_container_registry.0.login_server}"
+      docker_registry_url = var.linux_app_site_config.application_stack.docker_image == null ? null : "https://${module.mod_container_registry[0].login_server}"
       dotnet_version      = var.linux_app_site_config.application_stack.dotnet_version == null ? null : var.linux_app_site_config.application_stack.dotnet_version
       go_version          = var.linux_app_site_config.application_stack.go_version
       java_server         = var.linux_app_site_config.application_stack.java_server

--- a/resources.appservice.scaffolding.tf
+++ b/resources.appservice.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rg" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup?ref=v2.0.0"
 
   count = var.create_app_resource_group ? 1 : 0
 

--- a/resources.appservice.windows.tf
+++ b/resources.appservice.windows.tf
@@ -11,7 +11,7 @@ resource "azurerm_windows_web_app" "appService" {
   name                = local.app_service_name
   resource_group_name = local.resource_group_name
   location            = local.location
-  service_plan_id     = var.create_app_service_plan == false && var.existing_app_service_plan_name != null ? data.azurerm_service_plan.existing_asp.0.id : azurerm_service_plan.asp.0.id
+  service_plan_id     = var.create_app_service_plan == false && var.existing_app_service_plan_name != null ? data.azurerm_service_plan.existing_asp[0].id : azurerm_service_plan.asp[0].id
 
   key_vault_reference_identity_id = azurerm_user_assigned_identity.app_identity.id
   site_config {
@@ -24,7 +24,7 @@ resource "azurerm_windows_web_app" "appService" {
       # azurerm 4.x consolidated docker fields: `docker_container_*` are now
       # `docker_image_name` ("image:tag") plus `docker_registry_url`.
       docker_image_name            = var.windows_app_site_config.application_stack.docker_container_name == null ? null : "${var.windows_app_site_config.application_stack.docker_container_name}:${var.windows_app_site_config.application_stack.docker_container_tag == null ? "latest" : var.windows_app_site_config.application_stack.docker_container_tag}"
-      docker_registry_url          = var.windows_app_site_config.application_stack.docker_container_name == null ? null : "https://${var.create_app_container_registry ? module.mod_container_registry.0.login_server : var.windows_app_site_config.application_stack.docker_container_registry}"
+      docker_registry_url          = var.windows_app_site_config.application_stack.docker_container_name == null ? null : "https://${var.create_app_container_registry ? module.mod_container_registry[0].login_server : var.windows_app_site_config.application_stack.docker_container_registry}"
       dotnet_version               = var.windows_app_site_config.application_stack.dotnet_version
       dotnet_core_version          = var.windows_app_site_config.application_stack.dotnet_core_version
       tomcat_version               = var.windows_app_site_config.application_stack.tomcat_version

--- a/resources.appserviceplan.tf
+++ b/resources.appserviceplan.tf
@@ -7,7 +7,7 @@ resource "azurerm_service_plan" "asp" {
   location                   = local.location
   resource_group_name        = local.resource_group_name
   os_type                    = var.app_service_plan_os_type
-  app_service_environment_id = var.enable_app_service_environment == false ? null : data.azurerm_app_service_environment_v3.ase.0.id
+  app_service_environment_id = var.enable_app_service_environment == false ? null : data.azurerm_app_service_environment_v3.ase[0].id
 
   sku_name     = var.app_service_plan_sku_name
   worker_count = var.app_service_plan_worker_count

--- a/resources.locks.tf
+++ b/resources.locks.tf
@@ -8,7 +8,7 @@ resource "azurerm_management_lock" "resource_group_level_lock" {
   count = var.enable_resource_locks ? 1 : 0
 
   name       = "${local.resource_group_name}-${var.lock_level}-lock"
-  scope      = data.azurerm_resource_group.rg.0.id
+  scope      = data.azurerm_resource_group.rg[0].id
   lock_level = var.lock_level
   notes      = "Resource Group '${local.resource_group_name}' is locked with '${var.lock_level}' level."
 }


### PR DESCRIPTION
## Phase 4b — Mechanical tflint fixes

This PR applies automated mechanical fixes for ~4 tflint rule categories.
Closes part of #12.

### Violation reduction

| Metric | Count |
| --- | ---: |
| Before | 67 |
| After  | 3 |
| Reduction | 64 (95%) |

> "Before" is measured against the Phase 4 `.tflint.hcl` template
> (`.phase4-scratch/tflint.hcl` in the umbrella repo), applied locally for
> measurement only. This PR does **not** modify `.tflint.hcl` — that is
> handled by the parallel `chore/tflint-rules-enabled` PR (Phase 4) once
> the count drops below the 50-violation threshold.

### Fixes applied
- `terraform_deprecated_index`: `x.0.id` → `x[0].id`
- `terraform_typed_variables`: added `type = any` (or inferred type) to variable blocks missing a type
- `terraform_module_pinned_source`: pinned `github.com/POps-Rox/terraform-az(-entra)?-overlays-*` sources to `?ref=v2.0.0`
- `terraform_deprecated_interpolation`: `"${x}"` → `x`

### Left for manual follow-up
- `terraform_unused_declarations` — case-by-case review (some may be intentional public surface).
- `terraform_deprecated_lookup` — too risky to auto-rewrite `lookup(map, key)` → `map["key"]`.

### Validation
- `terraform fmt -recursive` — clean
- `terraform validate` — passes (when `terraform init -backend=false -upgrade` succeeds)

cc @JoshLuedeman
