### PR TITLE
chore(tflint): clean up unused declarations (1 Cat A, 2 Cat C)

### DIFF
--- a/variables.app.service.tf
+++ b/variables.app.service.tf
@@ -70,16 +70,11 @@ variable "deployment_slot_count" {
   default     = 0
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "create_app_storage_account" {
   description = "Controls if the storage account should be created. Default is true."
   type        = bool
   default     = true
-}
-
-variable "use_32_bit_worker" {
-  description = "Use 32 bit worker for the app service"
-  type        = bool
-  default     = false
 }
 
 variable "windows_app_site_config" {

--- a/variables.storage.tf
+++ b/variables.storage.tf
@@ -5,6 +5,7 @@
 # Storage Configuration    #
 ############################
 
+# tflint-ignore: terraform_unused_declarations
 variable "app_storage_account_name" {
   description = "Name of an existing storage account to use with the app service"
   type        = string


### PR DESCRIPTION
## Summary
Cleans up `terraform_unused_declarations` tflint warnings (3 total).

## Classification

### Cat A — Truly dead (removed)
| Variable | Reason |
|---|---|
| `use_32_bit_worker` | Redundant module-root duplicate. The same setting is already actively consumed via nested `site_config` objects in `resources.appservice.{linux,windows}.tf` and `resources.appservice.function.{linux,windows}.tf` (e.g. `var.windows_app_site_config.use_32_bit_worker`). The standalone variable was never wired and provides no fallback. |

### Cat C — Planned feature flags (annotated, tracked in #15)
| Variable | Intended behavior |
|---|---|
| `create_app_storage_account` | Gate whether `module.mod_storage_account` is invoked. |
| `app_storage_account_name` | Reference an existing storage account by name. |

These two form a coherent "bring your own storage account" feature that was never wired up. Issue #15 tracks implementation.

## Counts
- Cat A: 1
- Cat B: 0
- Cat C: 2

## Verification
```
$ tflint --enable-rule=terraform_unused_declarations
0 unused_declarations warnings remaining
```

Refs #12